### PR TITLE
cleanup error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,14 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
 base64 = "0.21.0"
 bytes = "1.3.0"
+eyre = "0.6.8"
 hex = "0.4.3"
 rand = "0.8.5"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0.38"
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["full"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,0 @@
-use std::result::Result as StdResult;
-
-use anyhow::Error as AnyhowError;
-
-/// A specialized `Result` type for rs-cnc.
-pub type Result<T> = StdResult<T, AnyhowError>;


### PR DESCRIPTION
This removes the unused error types, replaces `anyhow` by `eyre` (to mimick the changes in sequencer-relayer, which will make it easier to wrap the error) and provides some more context when errors are failing.