### PR TITLE
add rustls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,13 @@ bytes = "1.3.0"
 eyre = "0.6.8"
 hex = "0.4.3"
 rand = "0.8.5"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[features]
+default = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["full"] }


### PR DESCRIPTION
This allows configuring reqwest to use `rustls` instead of `openssl`, making cross compilation much easier.