### PR TITLE
use Url::join when constructing endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,13 @@ impl CelestiaNodeEndpoints {
     fn try_from_url(url: &Url) -> eyre::Result<Self> {
         let namespaced_data = url
             .join(NAMESPACED_DATA_ENDPOINT)
-            .wrap_err("failed creating URL for namespaced data endpoind")?;
+            .wrap_err("failed creating URL for namespaced data endpoint")?;
         let namespaced_shares = url
             .join(NAMESPACED_SHARES_ENDPOINT)
-            .wrap_err("failed creating URL for namespaced shares endpoind")?;
+            .wrap_err("failed creating URL for namespaced shares endpoint")?;
         let submit_pfd = url
             .join(SUBMIT_PFD_ENDPOINT)
-            .wrap_err("failed creating URL for submit pfd endpoind")?;
+            .wrap_err("failed creating URL for submit pfd endpoint")?;
 
         Ok(Self {
             namespaced_shares,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,12 @@ impl CelestiaNodeClientBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use reqwest::Url;
+
+    use super::{
+        CelestiaNodeClient, CelestiaNodeEndpoints, NAMESPACED_DATA_ENDPOINT,
+        NAMESPACED_SHARES_ENDPOINT, SUBMIT_PFD_ENDPOINT,
+    };
 
     #[test]
     fn constructing_client_without_base_url_is_err() {
@@ -329,5 +334,26 @@ mod tests {
             "base_url on CelestiaNodeClientBuilder not set",
             err.to_string()
         );
+    }
+
+    #[test]
+    fn base_url_is_made_into_proper_base_with_slash() {
+        let url_without_trailing_slash = "http://localdev.me/celestia";
+        let url_with_trailing_slash = format!("{url_without_trailing_slash}/");
+
+        let client = CelestiaNodeClient::new("http://localdev.me/celestia").unwrap();
+        assert_eq!(&url_with_trailing_slash, client.base_url.as_str());
+    }
+
+    #[test]
+    fn all_endpoints_are_proper_bases() {
+        let base_url = Url::parse("http://localdev.me/celestia/").unwrap();
+        let endpoints = CelestiaNodeEndpoints::try_from_url(&base_url).unwrap();
+        let namespaced_data = format!("{base_url}{NAMESPACED_DATA_ENDPOINT}");
+        let namespaced_shares = format!("{base_url}{NAMESPACED_SHARES_ENDPOINT}");
+        let submit_pfd = format!("{base_url}{SUBMIT_PFD_ENDPOINT}");
+        assert_eq!(namespaced_data, endpoints.namespaced_data.as_str());
+        assert_eq!(namespaced_shares, endpoints.namespaced_shares.as_str());
+        assert_eq!(submit_pfd, endpoints.submit_pfd.as_str());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,11 +205,11 @@ impl CelestiaNodeClient {
         let url = self
             .endpoints
             .namespaced_shares
-            .join(&format!("{namespace_id}/{height}/{height}"))
+            .join(&format!("{namespace_id}/height/{height}"))
             .wrap_err("failed constructing URL for namespaced shares endpoint")?;
 
         let response = self
-            .do_get::<NamespacedSharesResponse, _>(url)
+            .do_get(url)
             .await
             .wrap_err("failed getting namespaced shares from server")?;
         Ok(response)
@@ -227,7 +227,7 @@ impl CelestiaNodeClient {
             .wrap_err("failed constructing URL for namspaced data endpoint")?;
 
         let response = self
-            .do_get::<NamespacedDataResponse, _>(url)
+            .do_get(url)
             .await
             .wrap_err("failed getting namespaced data from server")?;
         Ok(response)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod types;
 // TODO - organize
 const NAMESPACED_DATA_ENDPOINT: &str = "namespaced_data/";
 const NAMESPACED_SHARES_ENDPOINT: &str = "namespaced_shares/";
-const SUBMIT_PFD_ENDPOINT: &str = "submit_pfd/";
+const SUBMIT_PFD_ENDPOINT: &str = "submit_pfd";
 
 #[derive(Serialize, Debug)]
 struct PayForDataRequest {
@@ -373,8 +373,7 @@ mod tests {
         let endpoints = CelestiaNodeEndpoints::try_from_url(&base_url).unwrap();
         let namespace_id = "123";
         let height = 4;
-        let expected_url =
-            format!("{base_url}{NAMESPACED_DATA_ENDPOINT}{namespace_id}/height/{height}");
+        let expected_url = "http://localdev.me/celestia/namespaced_data/123/height/4";
         let actual_url = endpoints
             .to_namespaced_data_url(namespace_id, height)
             .unwrap();
@@ -387,11 +386,18 @@ mod tests {
         let endpoints = CelestiaNodeEndpoints::try_from_url(&base_url).unwrap();
         let namespace_id = "123";
         let height = 4;
-        let expected_url =
-            format!("{base_url}{NAMESPACED_SHARES_ENDPOINT}{namespace_id}/height/{height}");
+        let expected_url = "http://localdev.me/celestia/namespaced_shares/123/height/4";
         let actual_url = endpoints
             .to_namespaced_shares_url(namespace_id, height)
             .unwrap();
         assert_eq!(expected_url, actual_url.as_str());
+    }
+
+    #[test]
+    fn submit_pfd_is_as_expected() {
+        let base_url = Url::parse("http://localdev.me/celestia/").unwrap();
+        let endpoints = CelestiaNodeEndpoints::try_from_url(&base_url).unwrap();
+        let expected_url = "http://localdev.me/celestia/submit_pfd";
+        assert_eq!(expected_url, endpoints.submit_pfd.as_str());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,6 +6,7 @@ async fn test_data_roundtrip() {
     let base_url = "http://localhost:26659";
     let client = CelestiaNodeClient::builder()
         .base_url(base_url)
+        .unwrap()
         .build()
         .unwrap();
 


### PR DESCRIPTION
This PR changes `base_url` from `String` to `Url` so that we can make use of `Url::join`. It also ensures that the URL that is passed in is always made into a "base URL" with a trailing slash.

Unfortunately this does not completely eliminate allocations because of how `Url` is implemented, but makes it a bit clearer.